### PR TITLE
fans: add LPHUMEX 1C 15C 1668

### DIFF
--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/1hour.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/1hour.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C4
+TE: 330

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/3hour.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/3hour.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C1
+TE: 330

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/6hour.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/6hour.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C3
+TE: 331

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Hi.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Hi.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C6
+TE: 331

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/LightOnOff.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/LightOnOff.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C5
+TE: 331

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Low.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Low.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C8
+TE: 330

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Med.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Med.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C C2
+TE: 331

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Mute.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Mute.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C CA
+TE: 331

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/README.md
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/README.md
@@ -1,0 +1,8 @@
+# LPHUMEX 1C 15C 1668
+
+Sub-GHz recordings from LPHUMEX 1C 15C 1668 Universal Ceiling Fan Remote kit.
+
+Product listing:
+https://www.amazon.com/Ceiling-Fan-Remote-Control-Universal/dp/B07VF3V52Y
+
+Recorded with Flipper Zero.

--- a/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Stop.sub
+++ b/Sub-GHz/Ceiling_Fans/LPHUMEX/1C15C1668/Stop.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 AC 8C CC
+TE: 331


### PR DESCRIPTION
# LPHUMEX 1C 15C 1668

Sub-GHz recordings from LPHUMEX 1C 15C 1668 Universal Ceiling Fan Remote kit.

Product listing:
https://www.amazon.com/Ceiling-Fan-Remote-Control-Universal/dp/B07VF3V52Y

Recorded with Flipper Zero.