### PR TITLE
unirf/fun.txt: Fix BruteT119, Tesla{270,650} paths

### DIFF
--- a/unirf/fun.txt
+++ b/unirf/fun.txt
@@ -1,7 +1,7 @@
 UP: /ext/subghz/Restaurant_Pagers/LRS_Pagers/BruteForceRest.sub
-DOWN: /ext/subghz/Restaurant_Pagers/Retekess_Pagers/Retekess_T119_Bruteforce.sub
-LEFT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/Better_Tesla_Charge_Port_Opener_315MHz_AM650.sub
-RIGHT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/Better_Tesla_Charge_Port_Opener_315MHz_AM270.sub
+DOWN: /ext/subghz/Restaurant_Pagers/Retekess_Pagers/T119/Retekess_T119_Bruteforce_Extended.sub
+LEFT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/315MHz_AM650_Better_Tesla_Charge_Port_Opener.sub
+RIGHT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/315MHz_AM270_Better_Tesla_Charge_Port_Opener.sub
 OK: /ext/subghz/Handicap/ook650_315substack.sub
 ULABEL: BruteLRS
 DLABEL: BruteT119


### PR DESCRIPTION
Updated unirf/fun.txt `DOWN` (BruteT119), `LEFT` (Tesla650) and `RIGHT` (Tesla270) paths so they point to actual SUB files.

Note that EU/AUS users might prefer the following sources :
```
LEFT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/433.92MHz_AM650_Better_Tesla_Charge_Port_Opener.sub
RIGHT: /ext/subghz/Vehicles/Tesla/BEST_PORT_OPENER/433.92MHz_AM270_Better_Tesla_Charge_Port_Opener.sub
```