### PR TITLE
Flipper SubGHz files to emulate the remote control for the Capstone I…

### DIFF
--- a/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_1.sub
+++ b/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_1.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 315000000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 5A A5 A4
+TE: 391

--- a/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_2.sub
+++ b/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_2.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 315000000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 5A A5 A2
+TE: 391

--- a/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_3.sub
+++ b/Sub-GHz/Remote_Outlet_Switches/Capstone_WRCO-RM/button_3.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 315000000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 5A A5 A8
+TE: 391


### PR DESCRIPTION
…ndustries Wireless Remote Control Outlet. (Remote control model WRCO-RM).

FCC ID 2ACN4WRCO-RM -- documentation at https://fccid.io/2ACN4WRCO-RM/