### PR TITLE
qFlipper auto install

### DIFF
--- a/BadUSB/qFlipper-windows.txt
+++ b/BadUSB/qFlipper-windows.txt
@@ -1,0 +1,22 @@
+REM made by DEXV#6969
+REM this script auto installs qFlipper
+DELAY 3000
+GUI r
+DELAY 1000
+STRING powershell (new-object System.Net.WebClient).DownloadFile('https://update.flipperzero.one/builds/qFlipper/1.2.2/qFlipperSetup-64bit-1.2.2.exe','%TEMP%\Dexv.exe'); Start-Process "%TEMP%\Dexv.exe"
+DELAY 500
+ENTER
+DELAY 750
+ALT SPACE
+STRING M
+DOWNARROW
+REPEAT 100
+ENTER
+DELAY 13000
+ENTER
+DELAY 1000
+ENTER
+DELAY 1000
+ENTER
+DELAY 4000
+ENTER


### PR DESCRIPTION
This bad-usb script installs the latest version of qFlipper and auto installs it i will improve the script later so i dont need to update the script everytime there is a new qFlipper update