### PR TITLE
update COMMAND to GUI

### DIFF
--- a/BadUSB/OSX_Rickroll.txt
+++ b/BadUSB/OSX_Rickroll.txt
@@ -17,7 +17,7 @@ DELAY 1000
 STRING open 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 ENTER
 DELAY 1000
-COMMAND TAB
+GUI TAB
 DELAY 100
 STRING osascript -e 'set volume 7' && killall Terminal
 ENTER


### PR DESCRIPTION
Update COMMAND to GUI to send a command key press on macOS.

Tested with this change and now successfully changes the volume and kills Terminal without throwing an error on the flipper.