### PR TITLE
Add GE Two-Melody Wireless Doorbell (manufactured by Jasco)

### DIFF
--- a/Sub-GHz/Doorbells/GE_2Melody_Doorbell/GE_Doorbell_dingdong.sub
+++ b/Sub-GHz/Doorbells/GE_2Melody_Doorbell/GE_Doorbell_dingdong.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 5D 90 B8
+TE: 214

--- a/Sub-GHz/Doorbells/GE_2Melody_Doorbell/README
+++ b/Sub-GHz/Doorbells/GE_2Melody_Doorbell/README
@@ -1,0 +1,4 @@
+GE-branded Wireless Doorbell Kit, 2 Melodies
+
+Manufacturer: Jasco Products Company, LLC
+Part Number: 19298


### PR DESCRIPTION
Entry-level "dumb" doorbell with GE branding, manufactured by Jasco