### PR TITLE
Add reverse command for Hampton_Bay_7 ceiling fan

### DIFF
--- a/Sub-GHz/Ceiling_Fans/Hampton_Bay_Ceiling_Fan_Complete/Hampton_Bay_7/HB_Reverse.sub
+++ b/Sub-GHz/Ceiling_Fans/Hampton_Bay_Ceiling_Fan_Complete/Hampton_Bay_7/HB_Reverse.sub
@@ -1,0 +1,8 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 302757000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Holtek_HT12X
+Bit: 12
+Key: 00 00 00 00 00 00 00 FB
+TE: 333


### PR DESCRIPTION
This adds a reverse command to one of the Hampton Bay fan remote groups. This was discovered by trying a bunch of different codes, not scanning a remote, so I'm not sure how applicable it is to other fans (but the code follows a clear pattern). Hopefully it's helpful for someone else who lost their remote!