### PR TITLE
Add SONOFF RF433 smart home remote

### DIFF
--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/1.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/1.sub
@@ -1,0 +1,9 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 58
+TE: 239
+Guard_time: 31

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/2.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/2.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 54
+TE: 240
+Guard_time: 31

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/3.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/3.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 52
+TE: 240
+Guard_time: 31

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/4.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/4.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 51
+TE: 238
+Guard_time: 30

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/5.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/5.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 5C
+TE: 241
+Guard_time: 31

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/6.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/6.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 59
+TE: 241
+Guard_time: 31

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/7.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/7.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 55
+TE: 239
+Guard_time: 30

--- a/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/8.sub
+++ b/Sub-GHz/Smart_Home_Remotes/Sonoff_RF433/8.sub
@@ -1,0 +1,11 @@
+Filetype: Flipper SubGhz Key File
+Version: 1
+Frequency: 433889000
+Preset: FuriHalSubGhzPresetOok650Async
+Latitute: 0.000000
+Longitude: 0.000000
+Protocol: Princeton
+Bit: 24
+Key: 00 00 00 00 00 68 EE 53
+TE: 240
+Guard_time: 31


### PR DESCRIPTION
Add the sub files for the SONOFF RF433 smart home remote

![image](https://github.com/user-attachments/assets/e5d88326-f907-42a8-9c19-88154f2f439f)
