### PR TITLE
Added Windows and MacOS ascii-live rickroll

### DIFF
--- a/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/MacOS Terminal Rickroll.txt
+++ b/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/MacOS Terminal Rickroll.txt
@@ -1,0 +1,22 @@
+ID 1234:5678 Apple:Keyboard
+REM You can change these values to VID/PID of original Apple keyboard
+REM to bypass Keyboard Setup Assistant
+
+REM This is BadUSB Terminal Rickroll script for MacOS Made by: PhoenixGod101 (https://github.com/PhoenixGod101)
+
+REM Note that when plugged into a mac it may give a popup warning about keyboards not working or something, feel free to click "quit" on that
+
+REM Open terminal window
+DELAY 1000
+GUI SPACE
+DELAY 500
+STRING terminal
+DELAY 500
+ENTER
+DELAY 1000
+
+STRING curl ascii.live/rick
+DELAY 500
+ENTER
+
+DEFAULT_DELAY 50

--- a/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/README.md
+++ b/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/README.md
@@ -1,6 +1,6 @@
 PLEASE READ
 
-ME (PhoenixGod101), hugomd OR UberGuidoZ WILL BE HELD RESPONSIBLE FOR ANY DAMAGES, THESE FILES ARE SAFE AND ANY HARM WILL BE THE USERS FAULT!!!
+ME (PhoenixGod101), hugomd OR UberGuidoZ WILL NOT BE HELD RESPONSIBLE FOR ANY DAMAGES, THESE FILES ARE SAFE AND ANY HARM WILL BE THE USERS FAULT!!!
 
 These two rickroll BadUSB files were created by PhoenixGod101 on GitHub
 (https://github.com/PhoenixGod101)

--- a/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/Windows CMD Rickroll.txt
+++ b/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/Windows CMD Rickroll.txt
@@ -1,0 +1,16 @@
+REM This is BadUSB CMD Rickroll script for Windows Made by: PhoenixGod101 (https://github.com/PhoenixGod101)
+
+REM Open windows cmd
+DELAY 1000
+GUI r
+DELAY 500
+STRING cmd
+DELAY 500
+ENTER
+DELAY 1000
+
+REM Play rickroll (https://github.com/hugomd/ascii-live)
+STRING curl ascii.live/rick
+DELAY 500
+ENTER
+DEFAULT_DELAY 50

--- a/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/readme.txt.txt
+++ b/BadUSB/Windows_MacOS_ascii-live_CMD_Rickroll/readme.txt.txt
@@ -1,0 +1,20 @@
+PLEASE READ
+
+ME (PhoenixGod101), hugomd OR UberGuidoZ WILL BE HELD RESPONSIBLE FOR ANY DAMAGES, THESE FILES ARE SAFE AND ANY HARM WILL BE THE USERS FAULT!!!
+
+These two rickroll BadUSB files were created by PhoenixGod101 on GitHub
+(https://github.com/PhoenixGod101)
+
+These files do not cause any damage and only run a command in cmd or terminal that can be easily stopped by pressing the keybind CTRL+C
+
+These two files open the terminal / command prompt on the device you are attacking and runs a command that utilises the GitHub Repository ascii-live made by hugomd
+(https://github.com/hugomd)
+(https://github.com/hugomd/ascii-live)
+
+To use, just plug the flipper zero into the device you are attacking and then run the code from your flipper. You may do this over Bluetooth too.
+
+Testing and Compatibility:
+These files have both been tested and both work. They were tested on Momentum FW using a USB connection. These files should work on any firmware, and should work over Bluetooth but haven't been tested using Bluetooth.
+
+Please Note:
+When using on apple, you may be given a pop up about keyboard settings, you do not need to worry about this and you may click quit. To counter this, plug your flipper into the apple device you wish to attack before the actual attack is run and quit the pop up. The device should remember the choice to quit the pop up and it should not appear again when you next do the attack on the same device.


### PR DESCRIPTION
I have made and added two of my custom-made BadUSB files that are completely harmless as they are a funny prank. These files rickroll the device they are targeting. I have tested these already, but feel free to test it yourself.

Key Features / What makes this different to all the other rickrolls out there:

- Runs in command prompt
- Infinite (as far as I'm aware) until manually stopped
- Can be stopped with an easy keyboard shortcut, CTRL-C
- Short command to run in cmd, less suspicious than those long PowerShell ones
- Credit given so users can go to the GitHub links to verify the code is safe themselves if they wish
- Unexpected, as no one expects an ASCII rickroll video to play in their command prompt
- Works on both Windows and macOS
- not flagged my antivirus (windows built-in anti-virus at least)

I hope you appreciate my work, I would love for you to accept this into your repository.
Thank you, PhoenixGod101.