### PR TITLE
Automated backup/release V2

### DIFF
--- a/.github/workflows/Snapshot.yml
+++ b/.github/workflows/Snapshot.yml
@@ -24,25 +24,25 @@ jobs:
 
     - name: Create a temporary directory for snapshot
       run: |
-        mkdir -p /tmp/repo-snapshot
-        rsync -av --exclude='.git' --exclude='.gitmodules' --exclude='.github' ./ /tmp/repo-snapshot/
+        mkdir -p /tmp/snapshot
+        rsync -av --exclude='.git' --exclude='.gitmodules' --exclude='.github' ./ /tmp/snapshot/
         rm -rf *
 
     - name: Create tar.zst snapshot
       run: |
-        cd /tmp/repo-snapshot
-        tar -I 'zstd -T0 -19' -cvf "$GITHUB_WORKSPACE/repo-snapshot-${{ steps.date.outputs.date }}.tar.zst" *
+        cd /tmp/snapshot
+        tar -I 'zstd -T0 -19' -cvf "$GITHUB_WORKSPACE/snapshot-${{ steps.date.outputs.date }}.tar.zst" *
         
     - name: Upload snapshot artifact
       uses: actions/upload-artifact@v4
       with:
-        name: repo-snapshot
-        path: repo-snapshot-${{ steps.date.outputs.date }}.tar.zst
+        name: snapshot
+        path: snapshot-${{ steps.date.outputs.date }}.tar.zst
 
     - name: Check if archive > 2GB and split if needed
       id: check_size
       run: |
-        file="repo-snapshot-${{ steps.date.outputs.date }}.tar.zst"
+        file="snapshot-${{ steps.date.outputs.date }}.tar.zst"
         max_size=$((2 * 1024 * 1024 * 1024))  # 2GB in bytes
         actual_size=$(stat -c%s "$file")
         if [ "$actual_size" -ge "$max_size" ]; then
@@ -61,9 +61,9 @@ jobs:
           Automated snapshot for ${{ steps.date.outputs.date }}.
           Note: If archive was split due to size >2GB use cat to join them together
           ```
-          cat repo-snapshot-${{ steps.date.outputs.date }}.tar.zst.* > combined-${{ steps.date.outputs.date }}.tar.zst
+          cat snapshot-${{ steps.date.outputs.date }}.tar.zst.* > snapshot-${{ steps.date.outputs.date }}.tar.zst
           ```
         files: |
-          ${{ steps.check_size.outputs.split == 'true' && format('repo-snapshot-{0}.tar.zst.*', steps.date.outputs.date) || format('repo-snapshot-{0}.tar.zst', steps.date.outputs.date) }}
+          ${{ steps.check_size.outputs.split == 'true' && format('snapshot-{0}.tar.zst.*', steps.date.outputs.date) || format('snapshot-{0}.tar.zst', steps.date.outputs.date) }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Snapshot.yml
+++ b/.github/workflows/Snapshot.yml
@@ -1,0 +1,69 @@
+name: Monthly Snapshot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'  # Runs at 00:00 UTC on the 1st of every month
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo with submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set date variables
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+    - name: Install zstd/rsync
+      run: sudo apt-get update && sudo apt-get install -y zstd rsync
+
+    - name: Create a temporary directory for snapshot
+      run: |
+        mkdir -p /tmp/repo-snapshot
+        rsync -av --exclude='.git' --exclude='.gitmodules' --exclude='.github' ./ /tmp/repo-snapshot/
+        rm -rf *
+
+    - name: Create tar.zst snapshot
+      run: |
+        cd /tmp/repo-snapshot
+        tar -I 'zstd -T0 -19' -cvf "$GITHUB_WORKSPACE/repo-snapshot-${{ steps.date.outputs.date }}.tar.zst" *
+        
+    - name: Upload snapshot artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: repo-snapshot
+        path: repo-snapshot-${{ steps.date.outputs.date }}.tar.zst
+
+    - name: Check if archive > 2GB and split if needed
+      id: check_size
+      run: |
+        file="repo-snapshot-${{ steps.date.outputs.date }}.tar.zst"
+        max_size=$((2 * 1024 * 1024 * 1024))  # 2GB in bytes
+        actual_size=$(stat -c%s "$file")
+        if [ "$actual_size" -ge "$max_size" ]; then
+          split -b 1996M "$file" "${file}."
+          echo "split=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "split=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: "Snapshot ${{ steps.date.outputs.date }}"
+        tag_name: "Snapshot-${{ steps.date.outputs.date }}"
+        body: |
+          Automated snapshot for ${{ steps.date.outputs.date }}.
+          Note: If archive was split due to size >2GB use cat to join them together
+          ```
+          cat repo-snapshot-${{ steps.date.outputs.date }}.tar.zst.* > combined-${{ steps.date.outputs.date }}.tar.zst
+          ```
+        files: |
+          ${{ steps.check_size.outputs.split == 'true' && format('repo-snapshot-{0}.tar.zst.*', steps.date.outputs.date) || format('repo-snapshot-{0}.tar.zst', steps.date.outputs.date) }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This time it uses github actions as I didn't know github had a free tier of 2,000 hours a month for their runners. So no external machines needed for this to create a snapshot of the repo including all of the submodules, then creates a release with said snapshot. The resulting tar.zst is 2.0GB, if you were to git clone --recursive the repo it's 6.9GB. A POC can be found on my fork.