### PR TITLE
Fix dead links in Sub-GHz docs

### DIFF
--- a/Sub-GHz/Fog_Machine/ReadMe.md
+++ b/Sub-GHz/Fog_Machine/ReadMe.md
@@ -2,7 +2,7 @@
 
 FCC ID: &emsp; &emsp; &nbsp; ZIFIL-1<br>
 Frequency: &ensp; &nbsp; 315 Mhz<br>
-FCC Reports: &nbsp; <a href="https://fcc.io/ZIFIL">https://fcc.io/ZIFIL</a><br>
+FCC Reports: &nbsp; <a href="https://fccid.io/ZIFIL-1">https://fccid.io/ZIFIL-1</a><br>
 <br>
 There was an original upload to @UberGuidoZ repo by @the0bone for a Theefun TFM01 fog machine. Thanks!<br>
 <br>

--- a/Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD157/README.md
+++ b/Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD157/README.md
@@ -1,5 +1,5 @@
 # TD157
 
-https://www.retekess.com/td157-guest-paging-system
+https://www.retekess.com/products/td157-guest-paging-system
 
 Collected at a restaurant while in use

--- a/Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD165/README.md
+++ b/Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD165/README.md
@@ -1,5 +1,5 @@
 # TD165
 
-https://www.retekess.com/td165-guest-paging-system
+https://www.retekess.com/products/td165-su-668-wireless-calling-system
 
 Collected at a coffee shop using Flipper Zero

--- a/Sub-GHz/Restaurant_Pagers/SubGHz_changes.md
+++ b/Sub-GHz/Restaurant_Pagers/SubGHz_changes.md
@@ -1,4 +1,4 @@
-https://github.com/flipperdevices/flipperzero-firmware/tree/dev/firmware/targets/f7/furi_hal/furi_hal_subghz.c
+https://github.com/flipperdevices/flipperzero-firmware/tree/dev/targets/f7/furi_hal/furi_hal_subghz.c
 
 Change `furi_hal_subghz_is_frequency_valid` and `furi_hal_subghz_set_frequency_and_path`
 


### PR DESCRIPTION
Checked a handful of links in the Sub-GHz docs and found 4 that no longer resolve. Fixed each one, no other changes.

- `Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD157/README.md`: `retekess.com/td157-guest-paging-system` -> `retekess.com/products/td157-guest-paging-system`
- `Sub-GHz/Restaurant_Pagers/Retekess_Pagers/TD165/README.md`: `retekess.com/td165-guest-paging-system` -> `retekess.com/products/td165-su-668-wireless-calling-system` (Retekess renamed the product page, same TD165 unit)
- `Sub-GHz/Fog_Machine/ReadMe.md`: `fcc.io/ZIFIL` -> `fccid.io/ZIFIL-1` (the fcc.io shortlink domain is gone entirely; FCC ID ZIFIL-1 is already listed a couple lines up in the doc)
- `Sub-GHz/Restaurant_Pagers/SubGHz_changes.md`: the GitHub link to `furi_hal_subghz.c` pointed at the old `firmware/targets/f7/...` path, which 404s since the firmware repo got reorganized. Updated to `targets/f7/...`, verified the referenced functions are still there.

Verified each old URL 404s and each new one loads before making the change. No content edits, just the URLs.
